### PR TITLE
Exampleコンポーネントのnot foundとLinterエラー対応

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -9,12 +9,10 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import HelloWorld from '@/components/HelloWorld.vue'; // @ is an alias to /src
-import Example from '@/components/Example.vue';
 
 @Component({
   components: {
-    HelloWorld: HelloWorld,
-    Example: Example,
+    HelloWorld,
   },
 })
 export default class Home extends Vue {}


### PR DESCRIPTION
Gitのソース上は
Example.vueが行方不明扱いになっているので
マージして問題を解決してね。